### PR TITLE
fix: remove client instance from shared data on close()

### DIFF
--- a/src/main/java/io/d11/aerospike/client/AerospikeClient.java
+++ b/src/main/java/io/d11/aerospike/client/AerospikeClient.java
@@ -53,8 +53,7 @@ public interface AerospikeClient extends AutoCloseable {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static AerospikeClient create(Vertx vertx, AerospikeConnectOptions connectOptions) {
-    String sharedInstanceName = "__AerospikeClient.__for.__" + connectOptions.getHost() + ":" + connectOptions.getPort();
-    return SharedDataUtils.getOrCreate(new io.vertx.reactivex.core.Vertx(vertx), sharedInstanceName,
+    return SharedDataUtils.getOrCreate(vertx, SharedDataUtils.getInstanceName(connectOptions.getHost(), connectOptions.getPort()),
         () -> new AerospikeClientImpl(vertx, connectOptions.updateClientPolicy()));
   }
 

--- a/src/main/java/io/d11/aerospike/client/impl/AerospikeClientImpl.java
+++ b/src/main/java/io/d11/aerospike/client/impl/AerospikeClientImpl.java
@@ -30,6 +30,7 @@ import io.d11.aerospike.listeners.QueryResultListenerImpl;
 import io.d11.aerospike.listeners.RecordArrayListenerImpl;
 import io.d11.aerospike.listeners.RecordListenerImpl;
 import io.d11.aerospike.listeners.WriteListenerImpl;
+import io.d11.aerospike.util.SharedDataUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -98,6 +99,7 @@ public class AerospikeClientImpl implements AerospikeClient {
   public void close() {
     if (aerospikeClient != null) {
       aerospikeClient.close();
+      SharedDataUtils.removeInstanceByName(vertx, SharedDataUtils.getInstanceName(connectOptions.getHost(), connectOptions.getPort()));
       aerospikeClient = null;
     }
   }

--- a/src/main/java/io/d11/aerospike/util/SharedDataUtils.java
+++ b/src/main/java/io/d11/aerospike/util/SharedDataUtils.java
@@ -2,18 +2,29 @@ package io.d11.aerospike.util;
 
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
-import io.vertx.reactivex.core.Vertx;
+import io.vertx.core.Vertx;
+import lombok.val;
 import java.util.function.Supplier;
 
 public final class SharedDataUtils {
   private static final String SHARED_DATA_MAP_NAME = "__vertx.sharedDataUtils";
+  private static final String SHARED_INSTANCE_FORMAT = "__AerospikeClient.__for.__{}:{}";
 
   public SharedDataUtils() {
   }
 
+  public static String getInstanceName(String host, Integer port) {
+    return String.format(SHARED_INSTANCE_FORMAT, host, port);
+  }
+
   public static <T> T getOrCreate(Vertx vertx, String name, Supplier<T> supplier) {
-    LocalMap<Object, Object> singletons = vertx.getDelegate().sharedData().getLocalMap(SHARED_DATA_MAP_NAME);
+    LocalMap<Object, Object> singletons = vertx.sharedData().getLocalMap(SHARED_DATA_MAP_NAME);
     return (T) ((ThreadSafe)singletons.computeIfAbsent(name, k -> new ThreadSafe(supplier.get()))).getObject();
+  }
+
+  public static <T> void removeInstanceByName(Vertx vertx, String name) {
+    val singletons = vertx.sharedData().getLocalMap(SHARED_DATA_MAP_NAME);
+    singletons.remove(name);
   }
 
   static class ThreadSafe<T> implements Shareable {


### PR DESCRIPTION
### Summary

When using shared client instance and trying to create a new instance after closing the current one, the create() method would give the old instance as it was not removed from vert.x sharedData on close(). 

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #19 