### PR TITLE
fix: maven cache in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-          
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
       
       - name: Install Dependencies
         run: .ci/scripts/install-deps.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         java-version: '8'
         distribution: 'adopt'
+        cache: 'maven'
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD

--- a/src/test/java/io/d11/aerospike/Constants.java
+++ b/src/test/java/io/d11/aerospike/Constants.java
@@ -7,7 +7,7 @@ public class Constants {
   public static final String AEROSPIKE_HOST = "aerospike.host";
   public static final String AEROSPIKE_PORT = "aerospike.port";
   public static final String AEROSPIKE_IMAGE_KEY = "aerospike.image";
-  public static final String DEFAULT_AEROSPIKE_IMAGE = "aerospike/aerospike-server";
+  public static final String DEFAULT_AEROSPIKE_IMAGE = "aerospike/aerospike-server:6.0.0.0";
   public static final String INIT_DATA_PATH = "src/test/resources/init.aql";
   public static final String INIT_DATA_PATH_IN_CONTAINER = "/aerospike-seed/init.aql";
 }


### PR DESCRIPTION
### Summary

- Use `setup-java` maven cache instead of explicitly caching `.m2`
- Use aerospike `6.0.0.0` for running tests

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX